### PR TITLE
Use bump2version instead of versioningit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "versioningit~=2.0"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 # Self-descriptive entries which should always be present
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "responsefun"
 description = ""
-dynamic = ["version"]
+version = "0.0.1"
 readme = "README.md"
 authors = [
     { name = "Antonia Papapostolou, Maximilian Scheurer" }
@@ -73,24 +73,6 @@ where = ["."]
 responsefun = [
     "py.typed"
 ]
-
-[tool.versioningit]
-default-version = "1+unknown"
-
-[tool.versioningit.format]
-distance = "{base_version}+{distance}.{vcs}{rev}"
-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
-
-[tool.versioningit.vcs]
-# The method key:
-method = "git"  # <- The method name
-# Parameters to pass to the method:
-match = ["*"]
-default-tag = "1.0.0"
-
-[tool.versioningit.write]
-file = "responsefun/_version.py"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "responsefun"
-description = ""
+description = "Fun with response function in the ADC framework."
 version = "0.0.1"
 readme = "README.md"
 authors = [

--- a/responsefun/__init__.py
+++ b/responsefun/__init__.py
@@ -1,4 +1,5 @@
 """ResponseFun Fun with Response Functions."""
-from ._version import __version__
+
+__version__ = "0.0.1"
 
 __all__ = ["__version__"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,11 @@ omit =
     # Omit generated versioneer
     responsefun/_version.py
 
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:responsefun/__init__.py]
+
+[bumpversion:file:pyproject.toml]


### PR DESCRIPTION
## Description
`versioningit` does not play nicely with builds from archives instead of git repo, as is done on c-f, so changing to `bump2version` to have correct versions in c-f releases.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [x] Ready to go